### PR TITLE
Make CMD+L a shortcut for Lossy toggle

### DIFF
--- a/imageoptim/Base.lproj/MainMenu.xib
+++ b/imageoptim/Base.lproj/MainMenu.xib
@@ -500,8 +500,7 @@ CA
                                     </binding>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Lossy minification" id="euw-8w-uMu">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="Lossy minification" keyEquivalent="l" id="euw-8w-uMu">
                                 <connections>
                                     <binding destination="562" name="value" keyPath="values.LossyEnabled" id="jRt-MT-XRv">
                                         <dictionary key="options">


### PR DESCRIPTION
I'm not sure if this is all that's required.

I didn't know how to add a Lossy toggle for when the images get dropped on the dock icon, which would also be a cool feature.

And finally, @pornel you should seriously make this a paid app which is available on the App store! I would love to pay for it.